### PR TITLE
Fixing DB connection

### DIFF
--- a/Modules/database_manager.py
+++ b/Modules/database_manager.py
@@ -33,11 +33,11 @@ class DatabaseManager(metaclass=Singleton):
         # connect to PostgreSQL (PSQL) database
         # FIXME: Insert actual credentials / read from Config
         connect_str = ("Driver={PostgreSQL UNICODE};"
-                       "Server=db;"
+                       "Server=localhost;"
                        "Port=5432;"
                        f"Database={database_name};"
                        "Uid=mecha3;"
-                       "Pwd=;"
+                       "Pwd=mecha3;"
                        "MaxVarcharSize=1024 * 1024 * 1024"
                        # Allow bigger VarcharSize to allow faster interaction
                        )

--- a/pytest.sh
+++ b/pytest.sh
@@ -1,4 +1,4 @@
-PGPASSWORD=postgres psql -c 'CREATE ROLE mecha3 LOGIN CREATEDB ENCRYPTED PASSWORD mecha3' -U postgres -h localhost
+PGPASSWORD=postgres psql -c 'CREATE ROLE mecha3 LOGIN CREATEDB ENCRYPTED PASSWORD \'mecha3\'' -U postgres -h localhost
 PGPASSWORD=postgres psql -c 'CREATE DATABASE mecha3 WITH OWNER = mecha3' -U postgres -h localhost
 curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
 chmod +x ./cc-test-reporter

--- a/pytest.sh
+++ b/pytest.sh
@@ -1,5 +1,5 @@
-PGPASSWORD=postgres psql -c 'CREATE ROLE mecha3 LOGIN CREATEDB ENCRYPTED PASSWORD \'mecha3\'' -U postgres -h localhost
-PGPASSWORD=postgres psql -c 'CREATE DATABASE mecha3 WITH OWNER = mecha3' -U postgres -h localhost
+PGPASSWORD=postgres psql -c "CREATE ROLE mecha3 LOGIN CREATEDB ENCRYPTED PASSWORD 'mecha3'" -U postgres -h localhost
+PGPASSWORD=postgres psql -c "CREATE DATABASE mecha3 WITH OWNER = mecha3" -U postgres -h localhost
 curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
 chmod +x ./cc-test-reporter
 ./cc-test-reporter before-build

--- a/pytest.sh
+++ b/pytest.sh
@@ -1,5 +1,5 @@
-psql -c 'CREATE ROLE mecha3 LOGIN CREATEDB' -U postgres -h db
-psql -c 'CREATE DATABASE mecha3 WITH OWNER = mecha3' -U postgres -h db
+PGPASSWORD=postgres psql -c 'CREATE ROLE mecha3 LOGIN CREATEDB ENCRYPTED PASSWORD mecha3' -U postgres -h localhost
+PGPASSWORD=postgres psql -c 'CREATE DATABASE mecha3 WITH OWNER = mecha3' -U postgres -h localhost
 curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
 chmod +x ./cc-test-reporter
 ./cc-test-reporter before-build


### PR DESCRIPTION
When using Docker for Windows/Docker for Mac, please use the provided dockerized psql server
For Docker on Linux, set the passwd for the postgres user to postgres, or edit the pytes.sh accordingly, then rebuild the container